### PR TITLE
Allow passing extra arguments to mock_mpiexec

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ To test the code without MPI, import mock_mpiexec from this package and run:
     mock_mpiexec(nproc, function_to_test)
 ```
 
+Extra Arguments
+---------------
+
+You can also supply `args=[...]` and `kwargs={...}` to `mock_mpiexec` and they will be passed
+to `function_to_test`:
+
+```
+    mock_mpiexec(nproc, function_to_test, args=[1,2,3], kwargs={'a':'b'})
+```
+
+mimics:
+
+```
+    import mpi4py
+    comm = MPI.COMM_WORLD
+    function_to_test(comm, 1, 2, 3, a='b')
+
+```
+
+This works if `args` and `kwargs` can be pickled (true for most basic python and numpy types).
+
 Caveats
 -------
 

--- a/mock_mpi/exec.py
+++ b/mock_mpi/exec.py
@@ -39,7 +39,7 @@ class Process(mp.Process):
         return self._exception
 
 
-def mock_mpiexec(nproc, target):
+def mock_mpiexec(nproc, target, args=None, kwargs=None):
     """Run a function, given as target, as though it were an MPI session using mpiexec -n nproc
     but using multiprocessing instead of mpi.
     """
@@ -62,7 +62,9 @@ def mock_mpiexec(nproc, target):
     ]
 
     # Make processes
-    procs = [Process(target=target, args=(comm,)) for comm in comms]
+    args = args or []
+    kwargs = kwargs or {}
+    procs = [Process(target=target, args=[comm] + args, kwargs=kwargs) for comm in comms]
 
     for p in procs:
         p.start()

--- a/mock_mpi/exec.py
+++ b/mock_mpi/exec.py
@@ -62,9 +62,9 @@ def mock_mpiexec(nproc, target, args=None, kwargs=None):
     ]
 
     # Make processes
-    args = args or []
+    args = args or ()
     kwargs = kwargs or {}
-    procs = [Process(target=target, args=[comm] + args, kwargs=kwargs) for comm in comms]
+    procs = [Process(target=target, args=(comm,) + tuple(args), kwargs=kwargs) for comm in comms]
 
     for p in procs:
         p.start()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='mock_mpi',
-    version='0.5.0',
+    version='0.6.0',
     description='A tool for mocking mpi4py for testing',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,0 +1,14 @@
+from mock_mpi import mock_mpiexec
+
+
+def f(comm, txt, index=0, index2=0):
+    assert txt == "abc"
+    assert index == index2
+
+
+def test_args():
+    mock_mpiexec(2, f, args=("abc",))
+    mock_mpiexec(2, f, args=["abc"])
+    mock_mpiexec(
+        2, f, args=["abc"], kwargs={"index": "cat", "index2": "cat"}
+    )


### PR DESCRIPTION
This allows `args=` and `kwargs=` to mpi_exec, and updates the readme and version number accordingly