### PR TITLE
Different API for passing args and kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ mimics:
 
 ```
 
-This works if the argments can be pickled (true for most basic python and numpy types).
+This works if the arguments can be pickled (true for most basic python and numpy types).
 
 Caveats
 -------

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ To test the code without MPI, import mock_mpiexec from this package and run:
 Extra Arguments
 ---------------
 
-You can also supply `args=[...]` and `kwargs={...}` to `mock_mpiexec` and they will be passed
-to `function_to_test`:
+You can also supply additional named or positional arguments to `mock_mpiexec` and they will be
+passed to `function_to_test`:
 
 ```
-    mock_mpiexec(nproc, function_to_test, args=[1,2,3], kwargs={'a':'b'})
+    mock_mpiexec(nproc, function_to_test, 1, 2, 3, a='b')
 ```
 
 mimics:
@@ -62,7 +62,7 @@ mimics:
 
 ```
 
-This works if `args` and `kwargs` can be pickled (true for most basic python and numpy types).
+This works if the argments can be pickled (true for most basic python and numpy types).
 
 Caveats
 -------

--- a/mock_mpi/exec.py
+++ b/mock_mpi/exec.py
@@ -29,7 +29,7 @@ class Process(mp.Process):
         return self._exception
 
 
-def mock_mpiexec(nproc, target, args=None, kwargs=None):
+def mock_mpiexec(nproc, target, *args, **kwargs):
     """Run a function, given as target, as though it were an MPI session using mpiexec -n nproc
     but using multiprocessing instead of mpi.
     """
@@ -52,9 +52,7 @@ def mock_mpiexec(nproc, target, args=None, kwargs=None):
     ]
 
     # Make processes
-    args = args or ()
-    kwargs = kwargs or {}
-    procs = [Process(target=target, args=(comm,) + tuple(args), kwargs=kwargs) for comm in comms]
+    procs = [Process(target=target, args=(comm,) + args, kwargs=kwargs) for comm in comms]
 
     for p in procs:
         p.start()

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -7,8 +7,9 @@ def f(comm, txt, index=0, index2=0):
 
 
 def test_args():
-    mock_mpiexec(2, f, args=("abc",))
-    mock_mpiexec(2, f, args=["abc"])
-    mock_mpiexec(
-        2, f, args=["abc"], kwargs={"index": "cat", "index2": "cat"}
-    )
+    mock_mpiexec(2, f, "abc")
+    mock_mpiexec(2, f, "abc", index="cat", index2="cat")
+    args = ["abc"]
+    mock_mpiexec(2, f, *args)
+    kwargs = {"index": "cat", "index2": "cat"}
+    mock_mpiexec(2, f, *args, **kwargs)

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -7,9 +7,18 @@ def f(comm, txt, index=0, index2=0):
 
 
 def test_args():
+    # direct args
     mock_mpiexec(2, f, "abc")
     mock_mpiexec(2, f, "abc", index="cat", index2="cat")
+
+    # if have args as list and kwargs as dict, can dereference them.
     args = ["abc"]
     mock_mpiexec(2, f, *args)
     kwargs = {"index": "cat", "index2": "cat"}
     mock_mpiexec(2, f, *args, **kwargs)
+
+    # can also dereference as literals, which is parobably weird, but allowed.
+    mock_mpiexec(2, f, *["abc"], **{"index": "cat", "index2": "cat"})
+
+if __name__ == '__main__':
+    test_args()


### PR DESCRIPTION
I was adjusting TreeCorr to use this package rather than my original file, and I discovered that I had already added the ability to pass args, but with a slightly different syntax.  Specifically, you just pass the args or kwargs as additional parameters to mpi_exec, rather than explicitly packaging them in a list or dict.  I think this is a bit cleaner.