### PR TITLE
Make IN_PLACE flag even if it's the real mpi4py IN_PLACE

### DIFF
--- a/mockmpi/comm.py
+++ b/mockmpi/comm.py
@@ -113,7 +113,7 @@ class MockComm(object):
         return d
 
     def Reduce(self, sendbuf, recvbuf, op=None, root=0):
-        if sendbuf is IN_PLACE:
+        if (sendbuf is IN_PLACE) or (isinstance(sendbuf, int) and sendbuf == IN_PLACE):
             sendbuf = recvbuf.copy()
 
         if not isinstance(sendbuf, np.ndarray):


### PR DESCRIPTION
Recent versions of mpi4py have `MPI.IN_PLACE` as a subclass of int, not just as a raw int. This breaks the use of that in the mock version.

This fixes it.