### PR TITLE
Allow IN_PLACE=-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 os: [ ubuntu-latest, macos-latest ]
-                py: [ 3.7, 3.8, 3.9 ]
+                py: [ 3.12, 3.13 ]
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set up Python ${{ matrix.py }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.py }}
 
             - name: Cache pip
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                 path: ~/.cache/pip
                 key: ${{ runner.os }}-${{ matrix.py }}-pip-${{ hashFiles('requirements.txt') }}

--- a/mockmpi/comm.py
+++ b/mockmpi/comm.py
@@ -3,9 +3,11 @@
 
 import numpy as np
 
-# This constant seems to have the same value in MPICH and OpenMPI
-# so we reproduce it here since it can be quite important.
-IN_PLACE = 1
+# This constant used to be 1 in both MPICH and OpenMPI,
+# but starting with mpi4py version 4, they switched it to -1.
+# Use -1 here, but when we check for it allow 1 as well.
+IN_PLACE = -1
+ALLOWED_IN_PLACE = [1, -1]
 
 
 class MockComm(object):
@@ -113,7 +115,7 @@ class MockComm(object):
         return d
 
     def Reduce(self, sendbuf, recvbuf, op=None, root=0):
-        if isinstance(sendbuf, int) and (sendbuf == IN_PLACE):
+        if isinstance(sendbuf, int) and (sendbuf in ALLOWED_IN_PLACE):
             sendbuf = recvbuf.copy()
 
         if not isinstance(sendbuf, np.ndarray):

--- a/mockmpi/comm.py
+++ b/mockmpi/comm.py
@@ -6,8 +6,12 @@ import numpy as np
 # This constant used to be 1 in both MPICH and OpenMPI,
 # but starting with mpi4py version 4, they switched it to -1.
 # Use -1 here, but when we check for it allow 1 as well.
-IN_PLACE = -1
-ALLOWED_IN_PLACE = [1, -1]
+# And if we happen to have mpi4py installed, include whatever it actually has as well.
+try:
+    from mpi4py.MPI import IN_PLACE
+except ImportError:
+    IN_PLACE = -1
+ALLOWED_IN_PLACE = [IN_PLACE, 1, -1]
 
 
 class MockComm(object):


### PR DESCRIPTION
mpi4py.IN_PLACE used to be 1 in all versions we knew about.  But starting with mpi4py version 4.0, they switched it to -1.

I changed the code where we check its value to allow for either value.